### PR TITLE
Default to serial execution of all image sets in a distro

### DIFF
--- a/autobuilder/abconfig.py
+++ b/autobuilder/abconfig.py
@@ -185,7 +185,7 @@ class EC2Params(object):
                  scratchvol=False, scratchvol_params=None,
                  instance_profile_name=None, spot_instance=False,
                  max_spot_price=None, price_multiplier=None,
-                 instance_types=None):
+                 instance_types=None, build_wait_timeout=None):
         self.instance_type = instance_type
         self.instance_types = instance_types
         self.ami = ami
@@ -195,6 +195,10 @@ class EC2Params(object):
         self.subnet = subnet
         self.elastic_ip = elastic_ip
         self.tags = tags
+        if build_wait_timeout:
+            self.build_wait_timeout = build_wait_timeout
+        else:
+            self.build_wait_timeout = 0 if spot_instance else 300
         if scratchvol:
             self.scratchvolparams = scratchvol_params or default_svp
         else:
@@ -465,6 +469,7 @@ class AutobuilderConfig(object):
                                                       tags=w.ec2tags,
                                                       block_device_map=w.ec2_dev_mapping,
                                                       spot_instance=w.ec2params.spot_instance,
+                                                      build_wait_timeout=w.ec2params.build_wait_timeout,
                                                       max_spot_price=w.ec2params.max_spot_price,
                                                       price_multiplier=w.ec2params.price_multiplier,
                                                       instance_types=w.ec2params.instance_types))

--- a/autobuilder/factory.py
+++ b/autobuilder/factory.py
@@ -72,8 +72,8 @@ def worker_extraconfig(props):
     abcfg = settings.get_config_for_builder(props.getProperty('autobuilder'))
     wcfg = abcfg.worker_cfgs[props.getProperty('workername')]
     if wcfg:
-        return wcfg.conftext or ''
-    return ''
+        return wcfg.conftext
+    return None
 
 
 @util.renderer

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ BUILDBOTVERSION = '2.9.2'
 
 setup(
     name='autobuilder',
-    version='2.8.0',
+    version='2.8.99',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
For image sets that are just variants of a distro, splitting their execution across multiple workers isn't really more cost-effective than just executing them serially on a single worker, so default to serial execution. 