### PR TITLE
More refactoring and cleanup

### DIFF
--- a/autobuilder/abconfig.py
+++ b/autobuilder/abconfig.py
@@ -42,35 +42,9 @@ class AutobuilderConfig(object):
         if name in settings_dict():
             raise RuntimeError('Autobuilder config {} already exists'.format(name))
         self.name = name
-        self.workers = []
-        self.worker_cfgs = {}
-        for w in workers:
-            if isinstance(w, AutobuilderEC2Worker):
-                self.workers.append(MyEC2LatentWorker(name=w.name,
-                                                      password=w.password,
-                                                      max_builds=w.max_builds,
-                                                      instance_type=w.ec2params.instance_type,
-                                                      ami=w.ec2params.ami,
-                                                      keypair_name=w.ec2params.keypair,
-                                                      instance_profile_name=w.ec2params.instance_profile_name,
-                                                      security_group_ids=w.ec2params.secgroup_ids,
-                                                      region=w.ec2params.region,
-                                                      subnet_id=w.ec2params.subnet,
-                                                      subnet_ids=w.ec2params.subnets,
-                                                      user_data=w.userdata(),
-                                                      elastic_ip=w.ec2params.elastic_ip,
-                                                      tags=w.ec2tags,
-                                                      block_device_map=w.ec2_dev_mapping,
-                                                      spot_instance=w.ec2params.spot_instance,
-                                                      build_wait_timeout=w.ec2params.build_wait_timeout,
-                                                      max_spot_price=w.ec2params.max_spot_price,
-                                                      price_multiplier=w.ec2params.price_multiplier,
-                                                      instance_types=w.ec2params.instance_types))
-            else:
-                self.workers.append(worker.Worker(w.name, w.password, max_builds=w.max_builds))
-            self.worker_cfgs[w.name] = w
-
-        self.worker_names = [w.name for w in workers]
+        self.workers = workers
+        self.worker_cfgs = {w.name: w for w in self.workers}
+        self.worker_names = [w.name for w in self.workers]
 
         self.repos = repos
         self.distros = distros or []

--- a/autobuilder/distros/config.py
+++ b/autobuilder/distros/config.py
@@ -2,7 +2,7 @@ from buildbot.plugins import util
 from buildbot.plugins import schedulers
 from buildbot.config import BuilderConfig
 
-from autobuilder.abconfig import AutobuilderForceScheduler, ABCFG_DICT
+from autobuilder.abconfig import AutobuilderForceScheduler, AutobuilderConfig
 from autobuilder.factory.distro import DistroImage
 from autobuilder.workers.ec2 import nextEC2Worker
 
@@ -173,10 +173,8 @@ class Distro(object):
                                                                       default=repos[self.reponame].uri),
                                        branch=util.FixedParameter(name='branch', default=self.branch))]
 
-    @property
-    def builders(self):
+    def builders(self, abcfg: AutobuilderConfig):
         if self._builders is None:
-            abcfg = ABCFG_DICT[self.abconfig]
             repo = abcfg.repos[self.reponame]
             props = {
                 'artifacts_path': self.artifacts_path,
@@ -214,10 +212,9 @@ class Distro(object):
                                                                     extra_env=self.extra_env))]
             return self._builders
 
-    @property
-    def schedulers(self):
+    def schedulers(self, abcfg: AutobuilderConfig):
         if self._schedulers is None:
-            repos = ABCFG_DICT[self.abconfig].repos
+            repos = abcfg.repos
             s = []
             if self.parallel_builders:
                 builder_names = [self.name + '-' + imgset.name for imgset in self.targets]

--- a/autobuilder/factory/base.py
+++ b/autobuilder/factory/base.py
@@ -44,14 +44,6 @@ def extract_env_vars(rc, stdout, stderr):
     return vardict
 
 
-def worker_extraconfig(props):
-    abcfg = abconfig.get_config_for_builder(props.getProperty('autobuilder'))
-    wcfg = abcfg.worker_cfgs[props.getProperty('workername')]
-    if wcfg:
-        return wcfg.conftext
-    return None
-
-
 @util.renderer
 def datestamp(props):
     return str(time.strftime("%Y%m%d"))

--- a/autobuilder/factory/distro.py
+++ b/autobuilder/factory/distro.py
@@ -5,7 +5,7 @@ from buildbot.process.factory import BuildFactory
 from buildbot.process.results import SKIPPED
 
 import autobuilder.abconfig as abconfig
-from autobuilder.factory.base import is_pull_request, worker_extraconfig
+from autobuilder.factory.base import is_pull_request
 from autobuilder.factory.base import extract_env_vars, dict_merge, ENV_VARS, datestamp
 
 
@@ -45,9 +45,9 @@ def make_autoconf(props):
     result = ['INHERIT += "rm_work buildstats-summary buildhistory"',
               'BUILDHISTORY_DIR = "${TOPDIR}/buildhistory"']
     # Worker-specific config
-    result += worker_extraconfig(props) or []
+    result += props.getProperty('worker_extraconf', default=[])
     # Distro-specific config
-    result += props.getProperty('extraconf') or []
+    result += props.getProperty('extraconf', default=[])
     # Buildtype-specific config
     result += _get_btinfo(props).extra_config or []
 

--- a/autobuilder/factory/layer.py
+++ b/autobuilder/factory/layer.py
@@ -5,16 +5,16 @@ from buildbot.plugins import util, steps
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import SKIPPED
 
-from autobuilder.factory.base import worker_extraconfig, datestamp, is_pull_request
+from autobuilder.factory.base import datestamp, is_pull_request
 from autobuilder.factory.base import extract_env_vars, dict_merge, ENV_VARS
 
 
 @util.renderer
 def make_layercheck_autoconf(props):
     # Worker-specific config
-    result = worker_extraconfig(props) or []
+    result = props.getProperty('worker_extraconf', default=[])
     # Distro-specific config
-    result += props.getProperty('extraconf') or []
+    result += props.getProperty('extraconf', default=[])
 
     return util.Interpolate('\n'.join(result) + '\n')
 

--- a/autobuilder/github/handler.py
+++ b/autobuilder/github/handler.py
@@ -6,12 +6,11 @@ from dateutil.parser import parse as dateparse
 from twisted.internet import defer
 from twisted.python import log
 
-import autobuilder.abconfig as abconfig
+from autobuilder.abconfig import ABCFG_DICT
 
 
 def get_project_for_url(repo_urls, branch):
-    for abcfg in abconfig.settings_dict():
-        cfg = abconfig.get_config_for_builder(abcfg)
+    for abcfg, cfg in ABCFG_DICT.items():
         for repo_url in repo_urls:
             try:
                 reponame = cfg.codebasemap[repo_url]
@@ -35,8 +34,7 @@ def layer_pr_filter(change: Change) -> bool:
     log.msg("layer_pr_filter: target_branch is {}".format(target_branch))
     if target_branch is None:
         return False
-    for abcfg in abconfig.settings_dict():
-        cfg = abconfig.get_config_for_builder(abcfg)
+    for abcfg, cfg in ABCFG_DICT.items():
         try:
             layer = cfg.layerdict[change.project]
             log.msg("layer_pr_filter: checking layer {}, branches={}".format(layer.name, layer.branches))
@@ -60,10 +58,10 @@ def codebasemap_from_github_payload(payload):
                 payload['repository']['ssh_url'],
                 payload['repository']['git_url']]
     reponame = ''
-    for abcfg in abconfig.settings_dict():
+    for abcfg, cfg in ABCFG_DICT.items():
         for url in urls:
             try:
-                reponame = abconfig.get_config_for_builder(abcfg).codebasemap[url]
+                reponame = cfg.codebasemap[url]
                 break
             except KeyError:
                 pass
@@ -80,8 +78,7 @@ def something_wants_pullrequests(payload):
             base['repo']['git_url'],
             base['repo']['ssh_url']]
     basebranch = base['ref']
-    for abcfg in abconfig.settings_dict():
-        cfg = abconfig.get_config_for_builder(abcfg)
+    for abcfg, cfg in ABCFG_DICT.items():
         for url in urls:
             try:
                 reponame = cfg.codebasemap[url]

--- a/autobuilder/layers/config.py
+++ b/autobuilder/layers/config.py
@@ -5,7 +5,7 @@ from buildbot.plugins import util
 from buildbot.config import BuilderConfig
 from buildbot.plugins import schedulers
 
-from autobuilder.abconfig import AutobuilderForceScheduler, ABCFG_DICT
+from autobuilder.abconfig import AutobuilderForceScheduler, AutobuilderConfig
 from autobuilder.github.handler import layer_pr_filter
 from autobuilder.factory.layer import CheckLayer
 from autobuilder.workers.ec2 import nextEC2Worker
@@ -53,10 +53,8 @@ class Layer(object):
                                                                          choices=self.branches,
                                                                          default=self.branches[0]))]
 
-    @property
-    def builders(self):
+    def builders(self, abcfg: AutobuilderConfig):
         if self._builders is None:
-            abcfg = ABCFG_DICT[self.abconfig]
             repo = abcfg.repos[self.reponame]
             self._builders = [
                 BuilderConfig(name=self.name + '-checklayer',
@@ -76,10 +74,9 @@ class Layer(object):
             ]
         return self._builders
 
-    @property
-    def schedulers(self):
+    def schedulers(self, abcfg: AutobuilderConfig):
         if self._schedulers is None:
-            repos = ABCFG_DICT[self.abconfig].repos
+            repos = abcfg.repos
             self._schedulers = [
                 schedulers.AnyBranchScheduler(
                     name=self.name + '-checklayer',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ BUILDBOTVERSION = '2.10.0'
 
 setup(
     name='autobuilder',
-    version='3.0.0',
+    version='3.1.0',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
* Removed separate worker config classes - both worker classes now directly subclass buildbot worker classes
* Implement worker-specific config additions as buildbot property
* Drops long-unused triggered schedulers
* Moves buildtype-related attributes to be buildbot properties attached to schedulers
* Drops some unneeded buildtype attributes that are no longer used and can be implemented via config additions
* Eliminates the extra functions that were used for ABCFG_DICT lookups