### PR TITLE
Fixes for PR handling of layer repos

### DIFF
--- a/autobuilder/layers/config.py
+++ b/autobuilder/layers/config.py
@@ -92,11 +92,12 @@ class Layer(object):
                     builderNames=[self.name + '-checklayer'])
             ]
             if self.pullrequests:
-                self._schedulers.append(schedulers.AnyBranchScheduler(
+                self._schedulers.append(schedulers.SingleBranchScheduler(
                     name=self.name + '-checklayer-pr',
-                    change_filter=util.ChangeFilter(filter_fn=layer_pr_filter),
+                    change_filter=util.ChangeFilter(filter_fn=layer_pr_filter,
+                                                    project=self.name,
+                                                    category=['pull']),
                     properties={'pullrequest': True},
-                    treeStableTimer=self.repotimer,
                     codebases=self.codebases(repos),
                     builderNames=[self.name + '-checklayer']))
         return self._schedulers

--- a/autobuilder/templates/cloud-init.txt
+++ b/autobuilder/templates/cloud-init.txt
@@ -15,6 +15,7 @@ package_upgrade: true
 packages:
     - build-essential
     - chrpath
+    - device-tree-compiler
     - socat
     - cpio
     - gawk

--- a/autobuilder/templates/cloud-init.txt
+++ b/autobuilder/templates/cloud-init.txt
@@ -73,7 +73,7 @@ runcmd:
     - python3 -m pip install buildbot-worker
     - python3 -m pip install https://github.com/madisongh/buildworker-scripts/releases/download/v0.1.0-pre3/buildworker_scripts-0.1.0-py3-none-any.whl
     - python3 -m pip install https://github.com/madisongh/git-credential-aws-secrets/releases/download/v0.0.2/git_credential_aws_secrets-0.0.2-py3-none-any.whl
-    - python3 -m pip install https://github.com/madisongh/digsigserver/releases/download/v0.3.5/digsigserver-0.3.5-py3-none-any.whl
+    - python3 -m pip install https://github.com/madisongh/digsigserver/releases/download/v0.3.6/digsigserver-0.3.6-py3-none-any.whl
     - mkdir /var/lib/bwsetup
     - [ sh, -c, "curl -L https://github.com/madisongh/buildworker-setup/releases/download/v0.2.2/buildworker-setup-0.2.2.tar.gz | tar -C /var/lib/bwsetup -x -z -f-" ]
     - [ sh, -c, "cd /var/lib/bwsetup/buildworker-setup-0.2.2; ./configure --prefix=/usr --with-buildbot-worker-prefix=/usr/local --with-digsig-prefix=/usr/local --with-keyfile-uri=s3://systems.madison.codesign-material && make && make install" ]

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 
-BUILDBOTVERSION = '2.10.0'
+BUILDBOTVERSION = '2.10.1'
 
 setup(
     name='autobuilder',
-    version='3.1.2',
+    version='3.1.3',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
Some cleanup in the Github webhook handler and the scheduler used for running layer PR builds, which appear to fix the problem with PRs to layer repos triggering extra (and wrong) builds.

Also includes:
* digsigserver bump and installation of dtc on workers, to support L4T R32.5.0 image signing
* buildbot version bump to 2.10.1