### PR TITLE
Updates

### DIFF
--- a/autobuilder/distros/config.py
+++ b/autobuilder/distros/config.py
@@ -129,7 +129,8 @@ class Distro(object):
                  pullrequest_type=None,
                  extra_config=None,
                  extra_env=None,
-                 parallel_builders=False):
+                 parallel_builders=False,
+                 worker_prefix=None):
         self.name = name
         self.reponame = reponame
         self.branch = branch
@@ -169,6 +170,7 @@ class Distro(object):
             self.extra_config = []
         self.extra_env = extra_env
         self.parallel_builders = parallel_builders
+        self.worker_prefix = worker_prefix
         self.abconfig = None
         self._builders = None
         self._schedulers = None
@@ -198,9 +200,13 @@ class Distro(object):
             }
             if self.artifacts:
                 props['artifacts'] = self.artifacts
+            if self.worker_prefix:
+                workernames = [wname for wname in abcfg.worker_names if wname.startswith(self.worker_prefix)]
+            else:
+                workernames = abcfg.worker_names
             if self.parallel_builders:
                 self._builders = [BuilderConfig(name=self.name + '-' + imgset.name,
-                                                workernames=abcfg.worker_names,
+                                                workernames=workernames,
                                                 nextWorker=nextEC2Worker,
                                                 properties=props,
                                                 factory=DistroImage(repourl=repo.uri,
@@ -212,7 +218,7 @@ class Distro(object):
                                   for imgset in self.targets]
             else:
                 self._builders = [BuilderConfig(name=self.name,
-                                                workernames=abcfg.worker_names,
+                                                workernames=workernames,
                                                 nextWorker=nextEC2Worker,
                                                 properties=props,
                                                 factory=DistroImage(repourl=repo.uri,

--- a/autobuilder/factory/distro.py
+++ b/autobuilder/factory/distro.py
@@ -60,6 +60,8 @@ class DistroImage(BuildFactory):
     def __init__(self, repourl, submodules=False, branch='master',
                  codebase='', imagesets=None, extra_env=None):
         BuildFactory.__init__(self)
+        if extra_env is None:
+            extra_env = {}
         self.addStep(steps.SetProperty(name='SetDatestamp',
                                        property='datestamp', value=datestamp))
         self.addStep(steps.Git(repourl=repourl, submodules=submodules,

--- a/autobuilder/factory/layer.py
+++ b/autobuilder/factory/layer.py
@@ -33,13 +33,15 @@ class CheckLayer(BuildFactory):
     def __init__(self, repourl, layerdir, pokyurl, codebase='', extra_env=None, machines=None,
                  extra_options=None, submodules=False):
         BuildFactory.__init__(self)
+        if extra_env is None:
+            extra_env = {}
         self.addStep(steps.SetProperty(name='SetDatestamp',
                                        property='datestamp', value=datestamp))
 
         branchcmd = 'targetbranch="%(prop:basename)s"; [ -n "$targetbranch" ] || targetbranch="%(prop:branch)s";' + \
                     'export targetbranch; export pokybranch=$(echo "$targetbranch" | cut -d- -f1); printenv'
         self.addStep(steps.SetPropertyFromCommand(command=['bash', '-c', util.Interpolate(branchcmd)],
-                                                  env=extra_env,
+                                                  env=extra_env or {},
                                                   extract_fn=extract_branch_names,
                                                   name='get_branch_names',
                                                   description="Extracting",

--- a/autobuilder/layers/config.py
+++ b/autobuilder/layers/config.py
@@ -19,7 +19,8 @@ class Layer(object):
                  machines=None,
                  extra_config=None,
                  extra_env=None,
-                 extra_options=None):
+                 extra_options=None,
+                 worker_prefix=None):
         self.name = name
         self.reponame = reponame
         self.pokyurl = pokyurl
@@ -32,6 +33,7 @@ class Layer(object):
         self.extra_config = extra_config
         self.extra_env = extra_env
         self.extra_options = extra_options
+        self.worker_prefix = worker_prefix
         self.abconfig = None
         self._builders = None
         self._schedulers = None
@@ -56,9 +58,13 @@ class Layer(object):
     def builders(self, abcfg: AutobuilderConfig):
         if self._builders is None:
             repo = abcfg.repos[self.reponame]
+            if self.worker_prefix:
+                workernames = [wname for wname in abcfg.worker_names if wname.startswith(self.worker_prefix)]
+            else:
+                workernames = abcfg.worker_names
             self._builders = [
                 BuilderConfig(name=self.name + '-checklayer',
-                              workernames=abcfg.worker_names,
+                              workernames=workernames,
                               nextWorker=nextEC2Worker,
                               properties=dict(project=self.name, repourl=repo.uri, autobuilder=self.abconfig,
                                               extraconf=self.extra_config or []),

--- a/autobuilder/templates/cloud-init-checklayer.txt
+++ b/autobuilder/templates/cloud-init-checklayer.txt
@@ -1,0 +1,48 @@
+#cloud-config
+bootcmd:
+    - [ mkdir, -p, /scratch ]
+
+package_update: true
+
+packages:
+    - build-essential
+    - chrpath
+    - diffstat
+    - python3-pip
+
+users:
+    - default
+    - name: builder
+      gecos: Auto Builder
+      lock_passwd: true
+      uid: "2000"
+      shell: /bin/bash
+
+write_files:
+    - content: |
+        WORKERNAME="{{ workername }}"
+        WORKERSECRET="{{ workersecret }}"
+        MASTER="{{ master_ip }}"
+      path: /run/buildworker/settings
+      permissions: '0600'
+    - content: |
+        {{ master_ip }} {{ master_hostname }} {{ master_fqdn }}
+      path: /etc/hosts
+      append: true
+
+runcmd:
+    - python3 -m pip install awscli
+    - python3 -m pip install boto3
+    - python3 -m pip install buildbot-worker
+    - python3 -m pip install https://github.com/madisongh/buildworker-scripts/releases/download/v0.1.0-pre3/buildworker_scripts-0.1.0-py3-none-any.whl
+    - python3 -m pip install https://github.com/madisongh/git-credential-aws-secrets/releases/download/v0.0.2/git_credential_aws_secrets-0.0.2-py3-none-any.whl
+    - mkdir /var/lib/bwsetup
+    - [ sh, -c, "curl -L https://github.com/madisongh/buildworker-setup/releases/download/v0.2.2/buildworker-setup-0.2.2.tar.gz | tar -C /var/lib/bwsetup -x -z -f-" ]
+    - [ sh, -c, "cd /var/lib/bwsetup/buildworker-setup-0.2.2; ./configure --prefix=/usr --with-buildbot-worker-prefix=/usr/local --with-systemdsystemunitdir=/lib/systemd/system && make && make install" ]
+    - systemctl enable buildworker-setup.service
+    - systemctl enable buildworker.service
+    - systemctl start buildworker-setup
+    {% for cmd in extra_cmds %}
+    - {{ cmd }}
+    {% endfor %}
+    - systemctl start buildworker

--- a/autobuilder/templates/cloud-init.txt
+++ b/autobuilder/templates/cloud-init.txt
@@ -74,7 +74,7 @@ runcmd:
     - python3 -m pip install buildbot-worker
     - python3 -m pip install https://github.com/madisongh/buildworker-scripts/releases/download/v0.1.0-pre3/buildworker_scripts-0.1.0-py3-none-any.whl
     - python3 -m pip install https://github.com/madisongh/git-credential-aws-secrets/releases/download/v0.0.2/git_credential_aws_secrets-0.0.2-py3-none-any.whl
-    - python3 -m pip install https://github.com/madisongh/digsigserver/releases/download/v0.3.6/digsigserver-0.3.6-py3-none-any.whl
+    - python3 -m pip install https://github.com/madisongh/digsigserver/releases/download/v0.4.0/digsigserver-0.4.0-py3-none-any.whl
     - mkdir /var/lib/bwsetup
     - [ sh, -c, "curl -L https://github.com/madisongh/buildworker-setup/releases/download/v0.2.2/buildworker-setup-0.2.2.tar.gz | tar -C /var/lib/bwsetup -x -z -f-" ]
     - [ sh, -c, "cd /var/lib/bwsetup/buildworker-setup-0.2.2; ./configure --prefix=/usr --with-buildbot-worker-prefix=/usr/local --with-digsig-prefix=/usr/local --with-keyfile-uri=s3://systems.madison.codesign-material && make && make install" ]

--- a/autobuilder/templates/default_mail.txt
+++ b/autobuilder/templates/default_mail.txt
@@ -1,3 +1,4 @@
 * {{ build['builder']['name'] }} build {{ build['number'] }}: {{ summary }}
     Details at: {{ build_url }}
+    {{ sourcestamps }}
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-BUILDBOTVERSION = '2.10.1'
+BUILDBOTVERSION = '3.0.2'
 
 setup(
     name='autobuilder',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ BUILDBOTVERSION = '3.0.2'
 
 setup(
     name='autobuilder',
-    version='3.1.3',
+    version='3.2.0',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
* Update buildbot to 3.0.2
* Add `worker_prefix` setting to `Distro()` and `Layer()` objects, to restrict builds to a subset of workers
* Added a `cloud-init-checklayer.txt` template for setting up smaller instances that will only perform layer checks
* Added sourcestamps to notification e-mails, to make it easier to tell which branch a build was done on when the branch name is not in the builder name

