### PR TITLE
Layercheck additions for handling layer dependencies

### DIFF
--- a/autobuilder/layers/config.py
+++ b/autobuilder/layers/config.py
@@ -20,7 +20,8 @@ class Layer(object):
                  extra_config=None,
                  extra_env=None,
                  extra_options=None,
-                 worker_prefix=None):
+                 worker_prefix=None,
+                 other_layers=None):
         self.name = name
         self.reponame = reponame
         self.pokyurl = pokyurl
@@ -34,6 +35,7 @@ class Layer(object):
         self.extra_env = extra_env
         self.extra_options = extra_options
         self.worker_prefix = worker_prefix
+        self.other_layers = other_layers
         self.abconfig = None
         self._builders = None
         self._schedulers = None
@@ -76,7 +78,8 @@ class Layer(object):
                                   codebase=self.reponame,
                                   extra_env=self.extra_env,
                                   machines=self.machines,
-                                  extra_options=self.extra_options))
+                                  extra_options=self.extra_options,
+                                  other_layers=self.other_layers))
             ]
         return self._builders
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ BUILDBOTVERSION = '3.3.0'
 
 setup(
     name='autobuilder',
-    version='3.5.0',
+    version='3.6.0',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
Adds `other_layers` argument to `Layer()` where you can configure
other layers needed by the layer being checked (using the `--dependency`
option to `yocto-check-layer`.