### PR TITLE
Update for dependent branch naming convention

### DIFF
--- a/autobuilder/factory/layer.py
+++ b/autobuilder/factory/layer.py
@@ -58,21 +58,18 @@ class CheckLayer(BuildFactory):
                                         descriptionSuffix=[pokyurl],
                                         descriptionDone="Cloned"))
         dep_args = []
-        for othername in other_layers:
-            other_layer = other_layers[othername]
-            if 'subdir' in other_layer:
-                subdir = other_layer['subdir']
-            else:
-                subdir = othername
+        for othername, other_layer in other_layers.items():
+            branchprop = 'targetbranch' if other_layer['use_target_branch'] else 'pokybranch'
+            subdir = other_layer['subdir']
             self.addStep(steps.ShellCommand(command=['git', 'clone',
-                                                     '--branch', util.Property('pokybranch'),
+                                                     '--branch', util.Property(branchprop),
                                                      '--depth', '1', other_layer['url'], subdir],
                                             name='{}_clone'.format(othername),
                                             workdir=os.path.join("build", "poky"),
                                             description="Cloning",
                                             descriptionSuffix=other_layer['url'],
                                             descriptionDone="Cloned"))
-            if 'sublayers' in other_layer:
+            if other_layer['sublayers']:
                 dep_args += [os.path.join('..', subdir, sub) for sub in other_layer['sublayers']]
             else:
                 dep_args.append(os.path.join('..', subdir))

--- a/autobuilder/layers/config.py
+++ b/autobuilder/layers/config.py
@@ -36,6 +36,14 @@ class Layer(object):
         self.extra_options = extra_options
         self.worker_prefix = worker_prefix
         self.other_layers = other_layers
+        if self.other_layers:
+            for lname, layer in self.other_layers.items():
+                if 'subdir' not in layer:
+                    layer['subdir'] = lname
+                if 'use_target_branch' not in layer:
+                    layer['use_target_branch'] = False
+                if 'sublayers' not in layer:
+                    layer['sublayers'] = None
         self.abconfig = None
         self._builders = None
         self._schedulers = None

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ BUILDBOTVERSION = '3.3.0'
 
 setup(
     name='autobuilder',
-    version='3.6.0',
+    version='3.6.1',
     packages=find_packages(),
     license='MIT',
     author='Matt Madison',


### PR DESCRIPTION
Dependent branch configurations for layer checks can set `'use_target_branch': True` to use the same branch name as the branch being targeted in the layer being checked (e.g., `dunfell-l4t-r32.5.0`) rather than the truncated (e.g., `dunfell`) name used by default.