### PR TITLE
Fixes for git checkouts on PRs

### DIFF
--- a/autobuilder/factory/layer.py
+++ b/autobuilder/factory/layer.py
@@ -7,7 +7,7 @@ from buildbot.process.results import SKIPPED
 
 from autobuilder.factory.base import datestamp, is_pull_request
 from autobuilder.factory.base import extract_env_vars, dict_merge, merge_env_vars
-
+from autobuilder.hackery import myGit
 
 @util.renderer
 def make_layercheck_autoconf(props):
@@ -87,14 +87,15 @@ class CheckLayer(BuildFactory):
                                method='clobber',
                                doStepIf=lambda step: not is_pull_request(step.build.getProperties()),
                                hideStepIf=lambda results, step: results == SKIPPED))
-        self.addStep(steps.Git(repourl=repourl, submodules=submodules,
-                               workdir=os.path.join("build", "poky", layerdir),
-                               branch=util.Property('branch'), codebase=codebase,
-                               name='git-checkout-pullrequest-ref',
-                               mode='full',
-                               method='clobber',
-                               doStepIf=lambda step: is_pull_request(step.build.getProperties()),
-                               hideStepIf=lambda results, step: results == SKIPPED))
+        self.addStep(myGit(repourl=repourl, submodules=submodules,
+                           workdir=os.path.join("build", "poky", layerdir),
+                           branch=util.Property('branch'), codebase=codebase,
+                           name='git-checkout-pullrequest-ref',
+                           mode='full',
+                           method='clobber',
+                           config=util.Property('gitconfig'),
+                           doStepIf=lambda step: is_pull_request(step.build.getProperties()),
+                           hideStepIf=lambda results, step: results == SKIPPED))
         # First, remove duplicates from original PATH (saved in ORIGPATH env var),
         # then strip out the virtualenv bin directory if we're in a virtualenv.
         setup_cmd = 'PATH=`echo -n "$ORIGPATH" | awk -v RS=: -v ORS=: \'!arr[$0]++\'`;' + \

--- a/autobuilder/github/handler.py
+++ b/autobuilder/github/handler.py
@@ -178,6 +178,11 @@ class AutobuilderGithubEventHandler(GitHubEventHandler):
         properties = self.extractProperties(payload['pull_request'])
         properties.update({'event': event, 'prnumber': number})
         properties.update({'basename': basename})
+        gitconfig = {
+            'gitconfig': {'remote.origin.fetch': '+refs/pull/{}/head:refs/remotes/origin/pr/{}'.format(number, number),
+                          'advice.detachedHead': 'false'}
+        }
+        properties.update(gitconfig)
         urls = [base['repo']['html_url'],
                 base['repo']['clone_url'],
                 base['repo']['git_url'],

--- a/autobuilder/hackery.py
+++ b/autobuilder/hackery.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
 from twisted.mail.smtp import ESMTPSender
+from buildbot.steps.source.git import Git
 
 
 class myESMTPSender(ESMTPSender, metaclass=ABCMeta):
@@ -16,3 +17,8 @@ class myESMTPSender(ESMTPSender, metaclass=ABCMeta):
                 return context
             except AttributeError:
                 return None
+
+
+class myGit(Git):
+    renderables = ["repourl", "reference", "branch",
+                   "codebase", "mode", "method", "origin", "config"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = autobuilder
-version = 3.9.8
+version = 3.9.9
 license = MIT
 license_files = LICENSE
 author = Matt Madison


### PR DESCRIPTION
Ensure that the needed refs for a PR are fetched when cloning, so the SHA can be found.